### PR TITLE
fixed cinder endpoint retrieval and corrected example file, fixes #17

### DIFF
--- a/examples/cfg/cfg.json
+++ b/examples/cfg/cfg.json
@@ -1,17 +1,17 @@
 {
-  "control": {},
-  "scheduler": {},
-  "plugins": {
-    "collector": {
-      "cinder": {
-        "all": {
-          "endpoint": "https://public.fuel.local:5000",
-          "user": "admin",
-          "password": "admin"
+  "control": {
+    "plugins": {
+      "collector": {
+        "cinder": {
+          "all": {
+            "endpoint": "http://localhost:5000/v2.0",
+            "user": "admin",
+            "password": "admin"
+          }
         }
-      }
-    },
-    "publisher": {},
-    "processor": {}
+      },
+      "publisher": {},
+      "processor": {}
+    }
   }
 }

--- a/openstack/common.go
+++ b/openstack/common.go
@@ -85,9 +85,8 @@ func (c Common) GetApiVersions(provider *gophercloud.ProviderClient) ([]string, 
 		return apis, err
 	}
 
-	pager := apiversionsintel.List(client)
-	page, err := pager.AllPages()
-	if err != nil {
+	page := apiversionsintel.Get(client)
+	if page.Err != nil {
 		fmt.Println("err ", err)
 		return apis, err
 	}


### PR DESCRIPTION
Fixes #17 
I happened that two things resulted in similar behavior:

1. Wrong protocol for keystone endpoint in example file (additionally, this file was malformed)
2. Cinder endpoint retrieval was done using function for reading paginated results, which has hardcoded set of correct http response codes. Response with cinder endpoints is not paginated and additionally has different set of http codes indicating valid response. On some configurations such unexpected code was misinterpreted as failed request. 

Summary of changes:
- Fixed malformed example config
- Used correct keystone endopoint
- Reimplemented endpoint retrieval

How to verify it:
- Check if error still occurs

Testing done:
- Manual
